### PR TITLE
Adding the ability to load samples from remote URLs via a browser path query string

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "redirects": [
+    { "source": "/*", "destination": "/index.html" }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,3 @@
 {
-  "redirects": [
-    { "source": "/(.*)", "destination": "/index.html" }
-  ]
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
   "redirects": [
-    { "source": "/*", "destination": "/index.html" }
+    { "source": "/(.*)", "destination": "/index.html" }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,7 @@
 {
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+  "version": 2,
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/.*", "dest": "/index.html" }
+  ]
 }


### PR DESCRIPTION
A quick change to allow the use of samples from remote URLs, so when loading Sema with an URL like

http://localhost:8080/playground/?samples=https://raw.githubusercontent.com/bthj/samples/master/test.wav,https://raw.githubusercontent.com/bthj/samples/master/test2.wav

then code like the following can be used in the Live Code Editor:

```
:x:{{{{1}clp, [3,9]}rsq}\test2,2,0.1}asymclip;
:z:{{{8}clp,[1,0]}rsq}\test;
> {:x:,:z:}sum;
```

Next steps could include adding some UI for this.